### PR TITLE
メトリクスの値を少し厳しくする

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -14,7 +14,7 @@ Rails:
 
 Metrics/ClassLength:
   CountComments: false
-  Max: 450
+  Max: 150
 
 Metrics/ModuleLength:
   CountComments: false
@@ -29,7 +29,10 @@ Metrics/LineLength:
     - https
 
 Metrics/MethodLength:
-  Max: 130
+  Max: 40
+  Exclude:
+    # データ移行のためにSQLを書くことがあるため許容する
+    - 'db/migrate/*.rb'
 
 Metrics/AbcSize:
   Max: 50


### PR DESCRIPTION
特定のファイルの影響で、メトリクスの値が緩すぎる設定になっていたので、少し厳しくしました。
該当のファイルもそれぞれ1つなので、 Forkwell のアプリ側では `Exclude` に追加しましょう。

RuboCop のデフォルトは `Metrics/ClassLength` が **100**, `Metrics/MethodLength` が **20** なので、段階的に少しずつ厳しくしていきたいと考えています。
