### PR TITLE
最近の対応した内容を forkwell_cop に反映する

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -37,6 +37,12 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Max: 50
 
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/PerceivedComplexity:
+  Max: 9
+
 # # 宗教の違いを許容する
 # def some_method_with_parameters param1, param2
 #  # body omitted

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -6,15 +6,6 @@ Lint/EnsureReturn:
 Lint/Eval:
   Enabled: true
 
-Metrics/CyclomaticComplexity:
-  Max: 12
-
-Metrics/ParameterLists:
-  Max: 8
-
-Metrics/PerceivedComplexity:
-  Max: 10
-
 Rails/Date:
   Enabled: true
 
@@ -36,9 +27,6 @@ Rails/Validation:
 Style/Alias:
   Enabled: true
 
-Style/AlignHash:
-  Enabled: true
-
 Style/AlignParameters:
   Enabled: true
 
@@ -47,9 +35,6 @@ Style/BlockDelimiters:
 
 Style/BracesAroundHashParameters:
   Enabled: false
-
-Style/CaseEquality:
-  Enabled: true
 
 Style/ClassAndModuleChildren:
   Enabled: false
@@ -69,19 +54,10 @@ Style/FormatString:
 Style/HashSyntax:
   Enabled: false
 
-Style/IfInsideElse:
-  Enabled: true
-
 Style/MultilineMethodCallIndentation:
   Enabled: false
 
-Style/PredicateName:
-  Enabled: true
-
 Style/SafeNavigation:
-  Enabled: true
-
-Style/SingleLineBlockParams:
   Enabled: true
 
 Style/VariableNumber:


### PR DESCRIPTION
ここ最近、Forkwell で対応した RuboCop の設定を反映しました。
## メトリクスについて
- `Metrics/CyclomaticComplexity`: 12 -> 10 (6)
- `Metrics/ParameterLists`: 8 -> 5 (5)
- `Metrics/PerceivedComplexity`: 10 -> 9 (7)

() 内は RuboCop の標準値(参照: [default.yml](https://github.com/bbatsov/rubocop/blob/v0.44.1/config/default.yml) )

`Metrics/ParameterLists` は rubocop のデフォルトと同じため、設定自体を yaml から消しました。
