### PR TITLE
RuboCop v0.44.1 に対応しました

### DIFF
--- a/config/todo.yml
+++ b/config/todo.yml
@@ -99,6 +99,3 @@ Rails/HttpPositionalArguments:
 
 Rails/DynamicFindBy:
   Enabled: false
-
-Style/ExtraSpacing:
-  Enabled: false

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -89,3 +89,16 @@ Style/VariableNumber:
 
 Style/GuardClause:
   Enabled: false
+
+# v0.44.0
+Metrics/BlockLength:
+  Enabled: false
+
+Rails/HttpPositionalArguments:
+  Enabled: false
+
+Rails/DynamicFindBy:
+  Enabled: false
+
+Style/ExtraSpacing:
+  Enabled: false

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.43.0'
+  spec.add_dependency 'rubocop', '~> 0.44.1'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
RuboCop v0.44.1 が出ていたので対応しました。
## やったこと
- [x] v0.44.1 に変更
  - 新しくチェックに引っかかるものは `Enabled: false` にしています
- [x] `Style/ExtraSpacing` は再度有効化
  - バグ修正によって Forkwell で新しく検出された
  - もともと有効になっていたものなので、 `Enabled: false` を消しました

他を有効にするのは、別途プルリクで議論して決めたいと思ってます。
