### PR TITLE
Rails/NotNullColumn を無効にする

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -87,3 +87,7 @@ Style/IndentHash:
 # ドキュメントの無い public クラスを許容する
 Style/Documentation:
   Enabled: false
+
+# email など NOT NULL でもデフォルト値を指定できないカラムは存在する
+Rails/NotNullColumn:
+  Enabled: false

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -12,9 +12,6 @@ Rails/Date:
 Rails/FindEach:
   Enabled: true
 
-Rails/NotNullColumn:
-  Enabled: true
-
 Rails/Output:
   Enabled: true
 


### PR DESCRIPTION
NOT NULL 制約についての cop ですが、 NOT NULL でもデフォルト値を設定できないカラムは存在するので無効にしたいと思います。

## 参照

[rails/not_null_column](https://github.com/bbatsov/rubocop/blob/v0.44.1/lib/rubocop/cop/rails/not_null_column.rb)