### PR TITLE
RuboCop v0.45.0 に対応

### DIFF
--- a/config/todo.yml
+++ b/config/todo.yml
@@ -64,18 +64,23 @@ Style/GuardClause:
   Enabled: false
 
 # v0.44.0
+# https://github.com/bbatsov/rubocop/blob/v0.45.0/lib/rubocop/cop/metrics/block_length.rb
 Metrics/BlockLength:
   Enabled: false
 
+# https://github.com/bbatsov/rubocop/blob/v0.45.0/lib/rubocop/cop/rails/http_positional_arguments.rb
 Rails/HttpPositionalArguments:
   Enabled: false
 
+# https://github.com/bbatsov/rubocop/blob/v0.45.0/lib/rubocop/cop/rails/dynamic_find_by.rb
 Rails/DynamicFindBy:
   Enabled: false
 
 # v0.45.0
+# https://github.com/bbatsov/rubocop/blob/v0.45.0/lib/rubocop/cop/style/multiline_if_modifier.rb
 Style/MultilineIfModifier:
   Enabled: false
 
+# https://github.com/bbatsov/rubocop/blob/v0.45.0/lib/rubocop/cop/style/space_in_lambda_literal.rb
 Style/SpaceInLambdaLiteral:
   Enabled: false

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -72,3 +72,10 @@ Rails/HttpPositionalArguments:
 
 Rails/DynamicFindBy:
   Enabled: false
+
+# v0.45.0
+Style/MultilineIfModifier:
+  Enabled: false
+
+Style/SpaceInLambdaLiteral:
+  Enabled: false

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.44.1'
+  spec.add_dependency 'rubocop', '~> 0.45.0'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
RuboCop v0.45.0 に上げました。

## やったこと

- [x] v0.45.0 に対応
  - 新しい cop で forkwell が引っかるものは `Enabled: false` にしてます

## 参考

RuboCop 0.45.0 のCHANGELOGを読む - SideCI TechBlog
http://tech.sideci.com/entry/2016/11/01/105900