### PR TITLE
RuboCop v0.46.0 に対応

### DIFF
--- a/config/todo.yml
+++ b/config/todo.yml
@@ -93,3 +93,8 @@ Bundler/OrderedGems:
 # https://github.com/bbatsov/rubocop/blob/v0.46.0/lib/rubocop/cop/style/empty_method.rb
 Style/EmptyMethod:
   Enabled: false
+
+# v0.46.0 ではエラーが発生するため無効にする。master では修正済み。
+# https://github.com/bbatsov/rubocop/pull/3751
+Rails/EnumUniqueness:
+  Enabled: false

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -84,3 +84,12 @@ Style/MultilineIfModifier:
 # https://github.com/bbatsov/rubocop/blob/v0.45.0/lib/rubocop/cop/style/space_in_lambda_literal.rb
 Style/SpaceInLambdaLiteral:
   Enabled: false
+
+# v0.46.0
+# https://github.com/bbatsov/rubocop/blob/v0.46.0/lib/rubocop/cop/bundler/ordered_gems.rb
+Bundler/OrderedGems:
+  Enabled: false
+
+# https://github.com/bbatsov/rubocop/blob/v0.46.0/lib/rubocop/cop/style/empty_method.rb
+Style/EmptyMethod:
+  Enabled: false

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.45.0'
+  spec.add_dependency 'rubocop', '~> 0.46.0'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
RuboCop v0.46.0 に上げました。

## やったこと

- [x] v0.46.0 に対応
  - 新しい cop で forkwell が引っかるものは `Enabled: false` にしてます
- [x] `Rails/EnumUniqueness` が変数指定でエラーになるので無効にしました
  - master では直っているので、次のアップデートでは `true` にして良いかも