### PR TITLE
:gem: Update to Rubocop v0.47.x

### DIFF
--- a/config/todo.yml
+++ b/config/todo.yml
@@ -94,7 +94,15 @@ Bundler/OrderedGems:
 Style/EmptyMethod:
   Enabled: false
 
-# v0.46.0 ではエラーが発生するため無効にする。master では修正済み。
-# https://github.com/bbatsov/rubocop/pull/3751
-Rails/EnumUniqueness:
+# v0.47.1
+# https://github.com/bbatsov/rubocop/blob/v0.47.1/lib/rubocop/cop/rails/file_path.rb
+Rails/FilePath:
+  Enabled: false
+
+# https://github.com/bbatsov/rubocop/blob/v0.47.1/lib/rubocop/cop/rails/reversible_migration.rb
+Rails/ReversibleMigration:
+  Enabled: false
+
+# https://github.com/bbatsov/rubocop/blob/v0.47.1/lib/rubocop/cop/rails/skips_model_validations.rb
+Rails/SkipsModelValidations:
   Enabled: false

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -3,7 +3,7 @@
 Lint/EnsureReturn:
   Enabled: true
 
-Lint/Eval:
+Security/Eval:
   Enabled: true
 
 Rails/Date:

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.46.0'
+  spec.add_dependency 'rubocop', '~> 0.47'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
RuboCop  v0.47 が使いたいので上げました。

https://github.com/bbatsov/rubocop/compare/v0.46.0...v0.47.1

## やったこと

- [x] v0.47.1 に対応
  - 新しい cop で forkwell が引っかるものは `Enabled: false` にしてます