### PR TITLE
いくつかの Cop に関して提案

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -104,19 +104,12 @@ Rails/NotNullColumn:
 Style/Alias:
   Enabled: false
 
-# # EnforcedStyle: with_fixed_indentation
+# - Emacs のデフォルトが with_first_parameter
+# - Vim のデフォルトが with_fixed_indentation
 #
-# # good
-#
-# foo :bar,
-#   :baz
-#
-# # bad
-#
-# foo :bar,
-#     :baz
+# という宗教の違いを許容する
 Layout/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
+  Enabled: false
 
 # データ移行のために execute を使うことがあるため許容する
 Rails/ReversibleMigration:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -96,3 +96,9 @@ Style/Documentation:
 # email など NOT NULL でもデフォルト値を指定できないカラムは存在する
 Rails/NotNullColumn:
   Enabled: false
+
+# alias, alias_method で細かい挙動が変わるため、使い分ける必要がある
+#
+# 参考: http://blog.bigbinary.com/2012/01/08/alias-vs-alias-method.html
+Style/Alias:
+  Enabled: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -116,3 +116,7 @@ Style/Alias:
 #     :baz
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+
+# データ移行のために execute を使うことがあるため許容する
+Rails/ReversibleMigration:
+  Enabled: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -102,3 +102,17 @@ Rails/NotNullColumn:
 # 参考: http://blog.bigbinary.com/2012/01/08/alias-vs-alias-method.html
 Style/Alias:
   Enabled: false
+
+# # EnforcedStyle: with_fixed_indentation
+#
+# # good
+#
+# foo :bar,
+#   :baz
+#
+# # bad
+#
+# foo :bar,
+#     :baz
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -68,6 +68,7 @@ Style/AccessorMethodName:
     #   @user = User.find(id)
     # end
     - '**/*_controller.rb'
+    - 'app/controllers/concerns/**/*.rb'
 
 # 日本語コメントを許容する
 Style/AsciiComments:

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -21,9 +21,6 @@ Rails/OutputSafety:
 Rails/Validation:
   Enabled: false
 
-Style/Alias:
-  Enabled: true
-
 Layout/AlignParameters:
   Enabled: true
 

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -39,9 +39,6 @@ Style/ClassVars:
 Style/DoubleNegation:
   Enabled: true
 
-Style/HashSyntax:
-  Enabled: false
-
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -83,10 +83,6 @@ Style/EmptyMethod:
 Rails/FilePath:
   Enabled: false
 
-# https://github.com/bbatsov/rubocop/blob/v0.47.1/lib/rubocop/cop/rails/reversible_migration.rb
-Rails/ReversibleMigration:
-  Enabled: false
-
 # https://github.com/bbatsov/rubocop/blob/v0.47.1/lib/rubocop/cop/rails/skips_model_validations.rb
 Rails/SkipsModelValidations:
   Enabled: false

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -21,9 +21,6 @@ Rails/OutputSafety:
 Rails/Validation:
   Enabled: false
 
-Layout/AlignParameters:
-  Enabled: true
-
 Style/BlockDelimiters:
   Enabled: false
 


### PR DESCRIPTION
RuboCop の設定について、いくつか設定案を作ったので、確認お願いします。
メンバーの全員が OK ならマージして、異論あるのはコミット外すのでコメントお願いしますー。

## Style/Alias

https://github.com/bbatsov/rubocop/blob/v0.49.1/lib/rubocop/cop/style/alias.rb

`alias` と `alias_method` の使い分けの Cop。

- 挙動の違いが分かりづらい
- RuboCop の autocorrect はあるけど、これでちゃんと直ると思えない（信頼できない）

ので、無効にしておきません？

## Layout/AlignParameters:

https://github.com/bbatsov/rubocop/blob/v0.49.1/lib/rubocop/cop/layout/align_parameters.rb

私の環境だと、vim の自動インデントが `with_fixed_indentation` で揃えられるので、この設定だと楽だなーと。
`with_first_parameter` が良いとか、無効が良い人がいれば意見が欲しいです。

##  Rails/ReversibleMigration

https://github.com/bbatsov/rubocop/blob/v0.49.1/lib/rubocop/cop/rails/reversible_migration.rb

コメントでも書いたように `execute` を書くことも多いので、無効にしておいた方が良いと思いました。

## Style/HashSyntax

https://github.com/bbatsov/rubocop/blob/v0.49.1/lib/rubocop/cop/style/hash_syntax.rb

今さら 1.8 時代の Hash 記法を使うことも無いので、デフォルトの `ruby19` で良いと思う。

## Style/AccessorMethodName

セッターメソッドを module に抽出したら検知されて鬱陶しいので、 `'app/controllers/concerns/**/*.rb'` を Exclude に追加。