### PR TITLE
map...flatten => flat_map をチェックする

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -96,3 +96,7 @@ Style/Documentation:
 # email など NOT NULL でもデフォルト値を指定できないカラムは存在する
 Rails/NotNullColumn:
   Enabled: false
+
+# map...flatten はだいたい flat_map に直せるのでチェックしておく
+Performance/FlatMap:
+  EnabledForFlattenWithoutParams: true


### PR DESCRIPTION
いつも私が指摘されるので、 RuboCop で自動検知した方が良さそうな気がしました。

## 備考

`flatten(1)` じゃない時は完全に等価じゃないので、誤検知の可能性がある。
ただ、ウチのコードで誤検知になるコードも無さそうなので有効にしても問題ないと思います。

## 参考

https://github.com/bbatsov/rubocop/blob/v0.49.1/lib/rubocop/cop/performance/flat_map.rb
https://github.com/bbatsov/rubocop/blob/v0.49.1/config/enabled.yml#L1445

