### PR TITLE
Update rubocop to v0.68.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
-before_install: gem install bundler -v 1.13.1
+before_install: gem install bundler -v 1.17.3
 notifications:
   email: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-performance
+
 AllCops:
   # .ruby-version の指定と合わせるため指定しない
   # TargetRubyVersion: ~

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -89,7 +89,7 @@ Style/LambdaCall:
 # and_in_a_method_call({
 #   no: :difference
 # })
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 # ドキュメントの無い public クラスを許容する

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path('../lib', __FILE__)

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.56'
+  spec.add_dependency 'rubocop', '~> 0.68'
+  spec.add_dependency 'rubocop-performance', '~> 1.3.0'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'forkwell_cop/version'
 

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 0.68'
   spec.add_dependency 'rubocop-performance', '~> 1.3.0'
-  spec.add_development_dependency 'bundler', '~> 1.13'
+  spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/forkwell_cop/version.rb
+++ b/lib/forkwell_cop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForkwellCop
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
依存しているrubocopのバージョンをあげました。

- Remove deprecation
- Fix some warning
- Update bundler to 1.17.3
