### PR TITLE
rubocop-rails の追加

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-performance
+  - rubocop-rails
 
 AllCops:
   # .ruby-version の指定と合わせるため指定しない

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rubocop', '~> 0.68'
   spec.add_dependency 'rubocop-performance', '~> 1.3.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.1.0'
   spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/forkwell_cop/version.rb
+++ b/lib/forkwell_cop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForkwellCop
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end


### PR DESCRIPTION
Rubocop から Rails に関する Cop が別管理となりました
https://github.com/rubocop-hq/rubocop/pull/7095

変更を追従をします