### PR TITLE
Follow up rubocop  v0.77.0

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -93,7 +93,7 @@ Style/LambdaCall:
 # and_in_a_method_call({
 #   no: :difference
 # })
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 # ドキュメントの無い public クラスを許容する
@@ -118,7 +118,7 @@ Style/Alias:
 # - Vim のデフォルトが with_fixed_indentation
 #
 # という宗教の違いを許容する
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 
 # データ移行のために execute を使うことがあるため許容する

--- a/config/todo.yml
+++ b/config/todo.yml
@@ -105,5 +105,5 @@ Naming/MemoizedInstanceVariableName:
   Enabled: false
 
 # https://github.com/bbatsov/rubocop/blob/v0.53.0/lib/rubocop/cop/naming/uncommunicative_method_param_name.rb
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '~> 0.68'
-  spec.add_dependency 'rubocop-performance', '~> 1.3.0'
-  spec.add_dependency 'rubocop-rails', '~> 2.1.0'
+  spec.add_dependency 'rubocop-performance', '~> 1.5.0'
+  spec.add_dependency 'rubocop-rails', '~> 2.4.0'
   spec.add_development_dependency 'bundler', '~> 1.17.3'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '~> 0.68'
   spec.add_dependency 'rubocop-performance', '~> 1.5.0'
   spec.add_dependency 'rubocop-rails', '~> 2.4.0'
-  spec.add_development_dependency 'bundler', '~> 1.17.3'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/forkwell_cop/version.rb
+++ b/lib/forkwell_cop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForkwellCop
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end


### PR DESCRIPTION
Forkwell 側で Rubocop v0.77.0 に対応するため依存 gem のアップデートを行います
加えて、Rubocop 0.77.0 で行われた copリネームの対応をします

- 依存gemsのアップデート
  - https://github.com/rubocop-hq/rubocop-performance/compare/v1.3.0...v1.5.1
  - https://github.com/rubocop-hq/rubocop-rails/compare/v2.1.0...v2.4.0
- Cop のリネーム
  - https://github.com/rubocop-hq/rubocop/pull/7468