### PR TITLE
Bump to v0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
-before_install: gem install bundler -v 1.17.3
+before_install: gem install bundler -v 2.1.4
 notifications:
   email: false

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '~> 0.68'
   spec.add_dependency 'rubocop-performance', '~> 1.5.0'
   spec.add_dependency 'rubocop-rails', '~> 2.4.0'
-  spec.add_development_dependency 'bundler', '~> 2.0.2'
+  spec.add_development_dependency 'bundler', '~> 2.1.4'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/forkwell_cop/version.rb
+++ b/lib/forkwell_cop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForkwellCop
-  VERSION = '0.8.0'
+  VERSION = '0.9.0'
 end


### PR DESCRIPTION
https://grooves.slack.com/archives/C02D057KV/p1574920220050900 にあるように 0.8.0 リリース時にwipコミットを誤操作で入れてしまったため、0.8.0 は yanked 扱いとなりました
https://rubygems.org/gems/forkwell_cop/versions

wipコミットを取り除き 0.9.0 としてリリースするため、バージョンをあげます 🙇 

## やったこと
- CI と Gemfile で Bundler のバージョンを揃える
- version を 0.9.0 へ変更