### PR TITLE
Update rubocop ~> 0.78

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -31,7 +31,7 @@ Metrics/ModuleLength:
   CountComments: false
   Max: 130
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 250
   AllowHeredoc: true
   AllowURI: true

--- a/forkwell_cop.gemspec
+++ b/forkwell_cop.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rubocop', '~> 0.68'
+  spec.add_dependency 'rubocop', '~> 0.78'
   spec.add_dependency 'rubocop-performance', '~> 1.5.0'
   spec.add_dependency 'rubocop-rails', '~> 2.4.0'
   spec.add_development_dependency 'bundler', '~> 2.1.4'

--- a/lib/forkwell_cop/version.rb
+++ b/lib/forkwell_cop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ForkwellCop
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
ref https://github.com/rubocop-hq/rubocop/pull/7542
rubocop 0.78でLineLengthがMetricsからLayoutに移っているので追随します。